### PR TITLE
Fix for URL not working and thus servers were not getting written.

### DIFF
--- a/lib/commands/default.js
+++ b/lib/commands/default.js
@@ -19,7 +19,7 @@ module.exports = function () {
 };
 
 function downloadServerConfig(cb) {
-    exec('curl -s http://labs-git.usersys.redhat.com/manager/api/servers.json', function (error, body) {
+    fs.readFile(path.join(__dirname, "../../", "servers.json"), "utf8", function (error, body) {
         if (error) {
             console.error('Errored downloading rc file');
             process.exit(1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "accessproxy",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "main": "index.js",
   "description": "A proxy for local access labs development",
   "homepage": "https://github.com/redhataccess/accessproxy",

--- a/servers.json
+++ b/servers.json
@@ -1,0 +1,9 @@
+{
+
+    "fte": "access.devgssfte.devlab.phx1.redhat.com",
+    "ci": "access.devgssci.devlab.phx1.redhat.com",
+    "qa": "access.qa.redhat.com",
+    "stage": "access.stage.redhat.com",
+    "prod": "access.redhat.com"
+    
+}


### PR DESCRIPTION
Fix for issue specified in ["downloadServerConfig" fails due to server url no longer exists. ](https://github.com/redhataccess/accessproxy/issues/4).

I have created a servers.json which contains the server related config.